### PR TITLE
Legg til fnrmaskering i loggene

### DIFF
--- a/src/main/java/no/nav/rekrutteringsbistand/sms/rekrutteringsbistandsms/utils/fnrmaskering/MaskedLoggingEvent.java
+++ b/src/main/java/no/nav/rekrutteringsbistand/sms/rekrutteringsbistandsms/utils/fnrmaskering/MaskedLoggingEvent.java
@@ -1,0 +1,106 @@
+package no.nav.rekrutteringsbistand.sms.rekrutteringsbistandsms.utils.fnrmaskering;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import org.slf4j.Marker;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MaskedLoggingEvent implements ILoggingEvent {
+    private final ILoggingEvent iLoggingEvent;
+
+    MaskedLoggingEvent(ILoggingEvent iLoggingEvent) {
+        this.iLoggingEvent = iLoggingEvent;
+    }
+
+    public static String mask(String string) {
+        return string != null ? string.replaceAll("(^|\\W)\\d{11}(?=$|\\W)", "$1***********") : null;
+    }
+
+    @Override
+    public String getThreadName() {
+        return iLoggingEvent.getThreadName();
+    }
+
+    @Override
+    public Level getLevel() {
+        return iLoggingEvent.getLevel();
+    }
+
+    @Override
+    public String getMessage() {
+        return iLoggingEvent.getMessage();
+    }
+
+    @Override
+    public Object[] getArgumentArray() {
+        return iLoggingEvent.getArgumentArray();
+    }
+
+    @Override
+    public String getFormattedMessage() {
+        return mask(iLoggingEvent.getFormattedMessage());
+    }
+
+
+    @Override
+    public String getLoggerName() {
+        return iLoggingEvent.getLoggerName();
+    }
+
+    @Override
+    public LoggerContextVO getLoggerContextVO() {
+        return iLoggingEvent.getLoggerContextVO();
+    }
+
+    @Override
+    public IThrowableProxy getThrowableProxy() {
+        return MaskedThrowableProxy.mask(iLoggingEvent.getThrowableProxy());
+    }
+
+    @Override
+    public StackTraceElement[] getCallerData() {
+        return iLoggingEvent.getCallerData();
+    }
+
+    @Override
+    public boolean hasCallerData() {
+        return iLoggingEvent.hasCallerData();
+    }
+
+    @Override
+    public Marker getMarker() {
+        return iLoggingEvent.getMarker();
+    }
+
+    @Override
+    public Map<String, String> getMDCPropertyMap() {
+        return new MaskedMap(iLoggingEvent.getMDCPropertyMap());
+    }
+
+    @Override
+    public Map<String, String> getMdc() {
+        return new MaskedMap(iLoggingEvent.getMdc());
+    }
+
+    @Override
+    public long getTimeStamp() {
+        return iLoggingEvent.getTimeStamp();
+    }
+
+    @Override
+    public void prepareForDeferredProcessing() {
+        iLoggingEvent.prepareForDeferredProcessing();
+    }
+
+
+    private static class MaskedMap extends HashMap<String, String> {
+        private MaskedMap(Map<String, String> map) {
+            map.forEach((k, v) -> MaskedMap.this.put(k, mask(v)));
+        }
+    }
+
+}

--- a/src/main/java/no/nav/rekrutteringsbistand/sms/rekrutteringsbistandsms/utils/fnrmaskering/MaskedThrowableProxy.java
+++ b/src/main/java/no/nav/rekrutteringsbistand/sms/rekrutteringsbistandsms/utils/fnrmaskering/MaskedThrowableProxy.java
@@ -1,0 +1,52 @@
+package no.nav.rekrutteringsbistand.sms.rekrutteringsbistandsms.utils.fnrmaskering;
+
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
+
+public class MaskedThrowableProxy implements IThrowableProxy {
+
+    private final IThrowableProxy throwableProxy;
+
+    private MaskedThrowableProxy(IThrowableProxy throwableProxy) {
+        this.throwableProxy = throwableProxy;
+    }
+
+    @Override
+    public String getMessage() {
+        return MaskedLoggingEvent.mask(throwableProxy.getMessage());
+    }
+
+    @Override
+    public String getClassName() {
+        return throwableProxy.getClassName();
+    }
+
+    @Override
+    public StackTraceElementProxy[] getStackTraceElementProxyArray() {
+        return throwableProxy.getStackTraceElementProxyArray();
+    }
+
+    @Override
+    public int getCommonFrames() {
+        return throwableProxy.getCommonFrames();
+    }
+
+    @Override
+    public IThrowableProxy getCause() {
+        return MaskedThrowableProxy.mask(throwableProxy.getCause());
+    }
+
+    public static IThrowableProxy mask(IThrowableProxy throwableProxy) {
+        return throwableProxy == null ? throwableProxy : new MaskedThrowableProxy(throwableProxy);
+    }
+
+    @Override
+    public IThrowableProxy[] getSuppressed() {
+        IThrowableProxy[] suppressed = throwableProxy.getSuppressed();
+        IThrowableProxy[] maskedSuppressed = new IThrowableProxy[suppressed.length];
+        for (int i = 0; i < suppressed.length; i++) {
+            maskedSuppressed[i] = mask(suppressed[i]);
+        }
+        return maskedSuppressed;
+    }
+}

--- a/src/main/java/no/nav/rekrutteringsbistand/sms/rekrutteringsbistandsms/utils/fnrmaskering/MaskingAppender.java
+++ b/src/main/java/no/nav/rekrutteringsbistand/sms/rekrutteringsbistandsms/utils/fnrmaskering/MaskingAppender.java
@@ -1,0 +1,20 @@
+package no.nav.rekrutteringsbistand.sms.rekrutteringsbistandsms.utils.fnrmaskering;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AppenderBase;
+
+public class MaskingAppender extends AppenderBase<ILoggingEvent> {
+
+    private Appender<ILoggingEvent> appender;
+
+    @Override
+    protected void append(ILoggingEvent iLoggingEvent) {
+        appender.doAppend(new MaskedLoggingEvent(iLoggingEvent));
+    }
+
+    @SuppressWarnings("unused")
+    public void setAppender(Appender<ILoggingEvent> appender) {
+        this.appender = appender;
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -9,8 +9,10 @@
         </appender>
     </springProfile>
     <springProfile name="dev | prod">
-        <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        <appender name="consoleAppender"  class="no.nav.rekrutteringsbistand.sms.rekrutteringsbistandsms.utils.fnrmaskering.MaskingAppender">
+            <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+            </appender>
         </appender>
         <logger name="jsonLogger" additivity="false" level="DEBUG">
             <appender-ref ref="consoleAppender"/>


### PR DESCRIPTION
Denne PRen legge til maskering av FNR i loggene.
Trenger det for å kunne slå på debuglogging av kall mot Altinn sin SMS-tjeneste via deres SOAP-bibliotek. Det biblioteket logger FNRet man prøver å sende SMSen til.